### PR TITLE
add retries to attempt to connect to bnb chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # Refund Bot
+
 Automated service for processing BEP3 refunds on Kava and Binance Chain.
 
 ## Set up
 
 Clone the example env file
+
 ```bash
 cp ./refund/example-env ./refund/.env
 ```
@@ -25,16 +27,20 @@ var main = async () => {
   // Initiate refund bot
   refundBot = new RefundBot(bnbChainDeputy);
   await refundBot.initKavaClient(kavaLcdURL, kavaMnemonic);
-  await refundBot.initBnbChainClient(bnbChainLcdURL, bnbChainMnemonic, "mainnet");
+  await refundBot.initBnbChainClient(
+    bnbChainLcdURL,
+    bnbChainMnemonic,
+    "mainnet"
+  );
 
   // Start cron job
   cron.schedule(cronTimer, () => {
-    refundBot.refundSwaps()
+    refundBot.refundSwaps();
   });
 
   // Optional: print Binance Chain offsets hourly for debugging
   cron.schedule("* 1 * * *", () => {
-    refundBot.printOffsets()
+    refundBot.printOffsets();
   });
-}
+};
 ```

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const RefundBot = require("./refund/refund").RefundBot;
 
 module.exports = {
-  RefundBot
+  RefundBot,
 };

--- a/refund/refund.js
+++ b/refund/refund.js
@@ -1,8 +1,8 @@
-require('dotenv').config();
-require('log-timestamp');
-const _ = require('lodash');
-const Kava = require('@kava-labs/javascript-sdk');
-const BnbChain = require('@binance-chain/javascript-sdk');
+require("dotenv").config();
+require("log-timestamp");
+const _ = require("lodash");
+const Kava = require("@kava-labs/javascript-sdk");
+const BnbChain = require("@binance-chain/javascript-sdk");
 const bnbCrypto = BnbChain.crypto;
 
 /**
@@ -16,7 +16,7 @@ class RefundBot {
     offsetOutgoing = 0
   ) {
     if (deputyAddresses.length == 0) {
-      throw new Error('must specify at least one Binance Chain deputy address');
+      throw new Error("must specify at least one Binance Chain deputy address");
     }
     this.deputyAddresses = deputyAddresses;
     this.limit = limit;
@@ -39,7 +39,7 @@ class RefundBot {
       throw new Error("Kava's chain's rpc-server url is required");
     }
     if (!mnemonic) {
-      throw new Error('Kava address mnemonic is required');
+      throw new Error("Kava address mnemonic is required");
     }
 
     // Initiate and set Kava client
@@ -67,7 +67,7 @@ class RefundBot {
       throw new Error("Binance Chain's rest-server url is required");
     }
     if (!mnemonic) {
-      throw new Error('Binance Chain address mnemonic is required');
+      throw new Error("Binance Chain address mnemonic is required");
     }
 
     // Start Binance Chain client
@@ -83,7 +83,7 @@ class RefundBot {
     }
 
     // Load our Binance Chain address (required for refunds)
-    const bnbAddrPrefix = network == 'mainnet' ? 'bnb' : 'tbnb';
+    const bnbAddrPrefix = network == "mainnet" ? "bnb" : "tbnb";
     this.bnbChainAddress = bnbCrypto.getAddressFromPrivateKey(
       privateKey,
       bnbAddrPrefix
@@ -96,7 +96,7 @@ class RefundBot {
    * Manages swap refunds
    */
   async refundSwaps() {
-    await this.refundKavaSwaps()
+    await this.refundKavaSwaps();
     await this.refundBinanceChainSwaps();
   }
 
@@ -120,21 +120,24 @@ class RefundBot {
     }
 
     // Refund each swap
-    let i = 0
-    await asyncForEach(swapIDs, async (swapID) =>  {
+    let i = 0;
+    await asyncForEach(swapIDs, async (swapID) => {
       const sequence = String(Number(accountData.sequence) + i);
       try {
         console.log(`\tRefunding swap ${swapID}`);
-        const fee = { amount: [{"denom": "ukava", "amount": "50000"}], gas: String(300000) };
+        const fee = {
+          amount: [{ denom: "ukava", amount: "50000" }],
+          gas: String(300000),
+        };
         const txHash = await this.kavaClient.refundSwap(swapID, fee, sequence);
-        console.log('\tTx hash:', txHash);
+        console.log("\tTx hash:", txHash);
       } catch (e) {
         console.log(`\tCould not refund swap ${swapID}`);
         console.log(e);
       }
       await sleep(25000); // Wait for the block to be confirmed
-      i++
-    })
+      i++;
+    });
   }
 
   /**
@@ -206,7 +209,7 @@ class RefundBot {
         console.log(`\t${e}`);
       }
       await sleep(5000); // Wait for the block to be confirmed
-    })
+    });
   }
 
   /**
@@ -219,8 +222,13 @@ class RefundBot {
     let offsetIncoming = this.offsetIncoming;
     let offsetOutgoing = this.offsetOutgoing;
 
-    const bnbInfo = await this.bnbClient._httpClient.request("get", "/api/v1/node-info")
-    const latestBnbBlockHeight = Number.parseInt(bnbInfo.result.sync_info.latest_block_height)
+    const bnbInfo = await this.bnbClient._httpClient.request(
+      "get",
+      "/api/v1/node-info"
+    );
+    const latestBnbBlockHeight = Number.parseInt(
+      bnbInfo.result.sync_info.latest_block_height
+    );
     // console.log(`Binance chain block height ${latestBnbBlockHeight}`)
 
     await asyncForEach(this.deputyAddresses, async (deputyAddress) => {
@@ -242,11 +250,11 @@ class RefundBot {
               offsetOutgoing
             );
           }
-          swapBatch = _.get(res, 'result.atomicSwaps');
+          swapBatch = _.get(res, "result.atomicSwaps");
         } catch (e) {
           console.log(
             `couldn't query ${
-              incoming ? 'incoming' : 'outgoing'
+              incoming ? "incoming" : "outgoing"
             } swaps on Binance Chain...`
           );
           return;
@@ -254,11 +262,12 @@ class RefundBot {
 
         // If swaps in batch, filter for expired swaps
         if (swapBatch && swapBatch.length > 0) {
-          const refundableSwapsInBatch = swapBatch.filter(
-            (swap) => {
-              return swap.status == 1 && Number.parseInt(swap.expireHeight) <= latestBnbBlockHeight
-            }
-          );
+          const refundableSwapsInBatch = swapBatch.filter((swap) => {
+            return (
+              swap.status == 1 &&
+              Number.parseInt(swap.expireHeight) <= latestBnbBlockHeight
+            );
+          });
           openSwaps = openSwaps.concat(refundableSwapsInBatch);
 
           // If it's a full batch, increment offset by limit for next iteration
@@ -276,7 +285,7 @@ class RefundBot {
           offsetOutgoing = this.offsetOutgoing;
         }
       }
-    })
+    });
 
     return openSwaps.map((swap) => swap.swapId);
   }
@@ -285,7 +294,7 @@ class RefundBot {
    * Print the current Binance Chain offsets to console
    */
   printOffsets() {
-    console.log('\nCurrent Binance Chain offsets:');
+    console.log("\nCurrent Binance Chain offsets:");
     console.log(`Offset incoming: ${this.offsetIncoming}`);
     console.log(`Offset outgoing: ${this.offsetOutgoing}\n`);
   }
@@ -307,6 +316,5 @@ var asyncForEach = async (array, callback) => {
     await callback(array[index], index, array);
   }
 };
-
 
 module.exports.RefundBot = RefundBot;

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -1,6 +1,6 @@
-require('dotenv').config({ path: process.env.ENV_FILE});
-const RefundBot = require('..').RefundBot;
-const cron = require('node-cron');
+require("dotenv").config({ path: process.env.ENV_FILE });
+const RefundBot = require("..").RefundBot;
+const cron = require("node-cron");
 
 var main = async () => {
   // Load environment variables
@@ -10,7 +10,7 @@ var main = async () => {
   const kavaMnemonic = process.env.KAVA_MNEMONIC;
   const bnbChainLcdURL = process.env.BINANCE_CHAIN_LCD_URL;
   const bnbChainMnemonic = process.env.BINANCE_CHAIN_MNEMONIC;
-  const deputyAddresses = process.env.BINANCE_CHAIN_DEPUTY_ADDRESSES.split(',');
+  const deputyAddresses = process.env.BINANCE_CHAIN_DEPUTY_ADDRESSES.split(",");
 
   // Initiate refund bot
   var refundBot = new RefundBot(deputyAddresses);
@@ -18,7 +18,7 @@ var main = async () => {
   await refundBot.initBnbChainClient(
     bnbChainLcdURL,
     bnbChainMnemonic,
-    'mainnet'
+    "mainnet"
   );
 
   // Start cron job
@@ -28,7 +28,7 @@ var main = async () => {
 
   // Print Binance Chain offsets hourly for debugging and future optimization.
   cron.schedule("* 1 * * *", () => {
-    refundBot.printOffsets()
+    refundBot.printOffsets();
   });
 };
 main();


### PR DESCRIPTION
uses exponential backoff to make service more resilient to brief api
outages on bnb chain.

majority of recent crashes have been due to an inability to fetch the
node-info endpoint. adding retries to that call should prevent these
crashes.